### PR TITLE
update ci.yml to fix package-lock conflicts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
 
       - name: Install Dependencies
         working-directory: ./ConcordiaMaps
-        run: npm install
+        run: npm ci
 
       - name: Lint Code
         working-directory: ./ConcordiaMaps
@@ -36,7 +36,7 @@ jobs:
 
       - name: Install Dependencies
         working-directory: ./ConcordiaMaps
-        run: npm install
+        run: npm ci
 
       - name: Lint Code
         working-directory: ./ConcordiaMaps


### PR DESCRIPTION
### **BUG FIX: resolving package-lock conflict problems**  

**Description**

We often had merge conflicts when trying to merge two branches where two people ran `npm install` and updated the `package-lock.json`. To fix this we simply updated the CI/CD pipeline to use `npm ci` and ask people to use `npm ci` instead of `npm install`

---

### **How was this tested?**  
**Manual Tests:**  
- [x] Tested running the `npm ci` and `npm install`
- [x] Checked if the CI/CD pipeline works with new changes
---


  