### PR TITLE
Get direction button works for selected buildings 

### DIFF
--- a/ConcordiaMaps/App.js
+++ b/ConcordiaMaps/App.js
@@ -1,4 +1,3 @@
-
 import React, { useState, createContext } from "react";
 import { NavigationContainer } from "@react-navigation/native";
 import { createNativeStackNavigator } from "@react-navigation/native-stack";

--- a/ConcordiaMaps/components/PopupModal.js
+++ b/ConcordiaMaps/components/PopupModal.js
@@ -10,6 +10,8 @@ import PropTypes from "prop-types";
 import styles from "../styles/DirectionBox.style";
 
 const PopupModal = ({ isVisible, data, onClose }) => {
+  const { name, fullBuildingName, address } = data;
+
   return (
     <Modal
       transparent
@@ -19,9 +21,9 @@ const PopupModal = ({ isVisible, data, onClose }) => {
     >
       <View style={styles.modalOverlay}>
         <View style={styles.modalContainer}>
-          <Text style={styles.modalTitle}>{data.name}</Text>
-          <Text style={styles.modalText1}>•••{data.fullBuildingName}•••</Text>
-          <Text style={styles.modalText}>{data.address}</Text>
+          <Text style={styles.modalTitle}>{name || "Building Name"}</Text>
+          <Text style={styles.modalText1}>{fullBuildingName || "Full Building Name"}</Text>
+          <Text style={styles.modalText}>{address || "Address not available"}</Text>
 
           <View style={styles.buttonsContainer}>
             <TouchableOpacity style={styles.closeButton} onPress={onClose}>
@@ -35,13 +37,16 @@ const PopupModal = ({ isVisible, data, onClose }) => {
               <Text style={styles.getDirectionsButtonText}>Get Directions</Text>
             </TouchableOpacity>
           </View>
-          
-          <TouchableOpacity
-            style={styles.getDirectionsButton1}
-            onPress={() => Alert.alert("Get Inner Directions", "Inner directions pressed")}
-          >
-            <Text style={styles.getDirectionsButtonText}>Get in Building Directions</Text>
-          </TouchableOpacity>
+
+          {/* Conditionally render the Get in Building Directions button */}
+          {name === "H Building" && (
+            <TouchableOpacity
+              style={styles.getDirectionsButton1}
+              onPress={() => Alert.alert("Get Inner Directions", "Inner directions pressed")}
+            >
+              <Text style={styles.getDirectionsButtonText}>Get in Building Directions</Text>
+            </TouchableOpacity>
+          )}
         </View>
       </View>
     </Modal>
@@ -52,13 +57,9 @@ PopupModal.propTypes = {
   isVisible: PropTypes.bool.isRequired,
   data: PropTypes.shape({
     name: PropTypes.string.isRequired,
-    coordinate: PropTypes.shape({
-      latitude: PropTypes.number,
-      longitude: PropTypes.number,
-    }),
-    address: PropTypes.string,
     fullBuildingName: PropTypes.string,
-  }),
+    address: PropTypes.string,
+  }).isRequired,
   onClose: PropTypes.func.isRequired,
 };
 

--- a/ConcordiaMaps/components/PopupModal.js
+++ b/ConcordiaMaps/components/PopupModal.js
@@ -1,11 +1,5 @@
 import React from "react";
-import {
-  Modal,
-  View,
-  Text,
-  TouchableOpacity,
-  Alert,
-} from "react-native";
+import { Modal, View, Text, TouchableOpacity, Alert } from "react-native";
 import PropTypes from "prop-types";
 import styles from "../styles/DirectionBox.style";
 
@@ -22,8 +16,12 @@ const PopupModal = ({ isVisible, data, onClose }) => {
       <View style={styles.modalOverlay}>
         <View style={styles.modalContainer}>
           <Text style={styles.modalTitle}>{name || "Building Name"}</Text>
-          <Text style={styles.modalText1}>{fullBuildingName || "Full Building Name"}</Text>
-          <Text style={styles.modalText}>{address || "Address not available"}</Text>
+          <Text style={styles.modalText1}>
+            {fullBuildingName || "Full Building Name"}
+          </Text>
+          <Text style={styles.modalText}>
+            {address || "Address not available"}
+          </Text>
 
           <View style={styles.buttonsContainer}>
             <TouchableOpacity style={styles.closeButton} onPress={onClose}>
@@ -32,21 +30,32 @@ const PopupModal = ({ isVisible, data, onClose }) => {
 
             <TouchableOpacity
               style={styles.getDirectionsButton}
-              onPress={() => Alert.alert("Get Directions", "Directions pressed")}
+              onPress={() =>
+                Alert.alert("Get Directions", "Directions pressed")
+              }
             >
               <Text style={styles.getDirectionsButtonText}>Get Directions</Text>
             </TouchableOpacity>
           </View>
 
-          {["H Building", "JMSB", "Vanier Library", "Central Building", "Vanier Extension" ].includes(name) && (
-  <TouchableOpacity
-    style={styles.getDirectionsButton1}
-    onPress={() => Alert.alert("Get Inner Directions", "Inner directions pressed")}
-  >
-    <Text style={styles.getDirectionsButtonText}>Get in Building Directions</Text>
-  </TouchableOpacity>
-)}
-
+          {[
+            "H Building",
+            "JMSB",
+            "Vanier Library",
+            "Central Building",
+            "Vanier Extension",
+          ].includes(name) && (
+            <TouchableOpacity
+              style={styles.getDirectionsButton1}
+              onPress={() =>
+                Alert.alert("Get Inner Directions", "Inner directions pressed")
+              }
+            >
+              <Text style={styles.getDirectionsButtonText}>
+                Get in Building Directions
+              </Text>
+            </TouchableOpacity>
+          )}
         </View>
       </View>
     </Modal>

--- a/ConcordiaMaps/components/PopupModal.js
+++ b/ConcordiaMaps/components/PopupModal.js
@@ -38,15 +38,15 @@ const PopupModal = ({ isVisible, data, onClose }) => {
             </TouchableOpacity>
           </View>
 
-          {/* Conditionally render the Get in Building Directions button */}
-          {name === "H Building" && (
-            <TouchableOpacity
-              style={styles.getDirectionsButton1}
-              onPress={() => Alert.alert("Get Inner Directions", "Inner directions pressed")}
-            >
-              <Text style={styles.getDirectionsButtonText}>Get in Building Directions</Text>
-            </TouchableOpacity>
-          )}
+          {["H Building", "JMSB", "Vanier Library", "Central Building"].includes(name) && (
+  <TouchableOpacity
+    style={styles.getDirectionsButton1}
+    onPress={() => Alert.alert("Get Inner Directions", "Inner directions pressed")}
+  >
+    <Text style={styles.getDirectionsButtonText}>Get in Building Directions</Text>
+  </TouchableOpacity>
+)}
+
         </View>
       </View>
     </Modal>

--- a/ConcordiaMaps/components/PopupModal.js
+++ b/ConcordiaMaps/components/PopupModal.js
@@ -38,7 +38,7 @@ const PopupModal = ({ isVisible, data, onClose }) => {
             </TouchableOpacity>
           </View>
 
-          {["H Building", "JMSB", "Vanier Library", "Central Building"].includes(name) && (
+          {["H Building", "JMSB", "Vanier Library", "Central Building", "Vanier Extension" ].includes(name) && (
   <TouchableOpacity
     style={styles.getDirectionsButton1}
     onPress={() => Alert.alert("Get Inner Directions", "Inner directions pressed")}


### PR DESCRIPTION
**Feature: get direction button**


---
Description: This feature allows users to obtain specific directions to navigate inside the building. Once the user clicks on the "Get in Building Directions" button, the app will provide detailed guidance on how to move around the building, such as which rooms, hallways, or floors to take. It's designed to be helpful for larger buildings with complex layouts where users might need to find a particular room, office, or facility inside the building.

**How was this tested?**
Manual Tests:
- [x] Verified that only the selected buildings have the button whilst the other ones don't have it in their popups.

---
**Visual Representation:**

https://github.com/user-attachments/assets/5e6cb096-20f3-453a-82bf-620e4f2cfe84

