### PR TITLE
BugFix:  Change MB 2nd floor to MB S2

### DIFF
--- a/ConcordiaMaps/__tests__/services/BuildingDataService.test.js
+++ b/ConcordiaMaps/__tests__/services/BuildingDataService.test.js
@@ -437,8 +437,8 @@ describe("edge cases in FloorRegistry methods", () => {
     const jmsb1 = FloorRegistry.getFloor("JMSB", "1");
     expect(jmsb1.description).toBe("First floor of JMSB");
 
-    const jmsb2 = FloorRegistry.getFloor("JMSB", "2");
-    expect(jmsb2.description).toBe("Second floor of JMSB");
+    const jmsb2 = FloorRegistry.getFloor("JMSB", "S2");
+    expect(jmsb2.description).toBe("Second-lowest floor of JMSB");
 
     // Vanier Library floor
     const vl1 = FloorRegistry.getFloor("VanierLibrary", "1");
@@ -451,7 +451,7 @@ describe("edge cases in FloorRegistry methods", () => {
     const jmsb1Nav = FloorRegistry.supportsNavigation("JMSB", "1");
     expect(jmsb1Nav).toBe(true);
 
-    const jmsb2Nav = FloorRegistry.supportsNavigation("JMSB", "2");
+    const jmsb2Nav = FloorRegistry.supportsNavigation("JMSB", "S2");
     expect(jmsb2Nav).toBe(true);
 
     const jmsbTNav = FloorRegistry.supportsNavigation("JMSB", "T");
@@ -482,7 +482,7 @@ describe("edge cases in FloorRegistry methods", () => {
     const jmsb1SVG = await FloorRegistry.getFloorPlan("JMSB", "1");
     expect(jmsb1SVG).toBe("<svg>MB Floor 1</svg>");
 
-    const jmsb2SVG = await FloorRegistry.getFloorPlan("JMSB", "2");
+    const jmsb2SVG = await FloorRegistry.getFloorPlan("JMSB", "S2");
     expect(jmsb2SVG).toBe("<svg>MB Floor 2</svg>");
 
     // VE SVGs

--- a/ConcordiaMaps/services/BuildingDataService.js
+++ b/ConcordiaMaps/services/BuildingDataService.js
@@ -109,10 +109,10 @@ class FloorRegistry {
           graph: JMSB1Graph,
           getSVG: () => SVGs.MBfloor1SVG,
         },
-        2: {
-          id: "2",
-          name: "MSB 2",
-          description: "Second floor of JMSB",
+        S2: {
+          id: "S2",
+          name: "MSB S2",
+          description: "Second-lowest floor of JMSB",
           rooms: JMSB2Rooms,
           graph: JMSB2Graph,
           getSVG: () => SVGs.MBfloor2SVG,


### PR DESCRIPTION
This bug fix fixes the issue described in [bug#198](https://github.com/SOEN-390-pmzone/SOEN-_390-Q-QD/issues/198)

Fix: Change the building data service file to show the floor as S2 instead of simply 2

![Screenshot_20250403-160916](https://github.com/user-attachments/assets/62cb8b57-31f9-457e-aff8-474c93e7a044)
